### PR TITLE
Add note on EC2 security groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Example commands are given from the perspective of running Ubuntu
 - DISK: 25 GB+
 
 - *Note: EC2 will only give you 5 IPs per region*
+- *Note: When creating an EC2 instance you'll have to add rules to it's security group that allow access to ports 9735 and 10009*
 
 ### Disk:
 


### PR DESCRIPTION
When launching an EC2 instance, AWS' launch wizard leads users to associate the default security group to it, which only opens the port needed for SSH access, thus it's quite easy to run into problems later when attempting to connect to that instance.

This PR attempts to improve the user flow and prevent this kind of error by explicitly mentioning this step.